### PR TITLE
Fix 'Illuminate\Foundation\Events\Dispatchable' not found

### DIFF
--- a/src/Events/RequestEvent.php
+++ b/src/Events/RequestEvent.php
@@ -4,11 +4,11 @@ namespace Appstract\LushHttp\Events;
 
 use Illuminate\Queue\SerializesModels;
 use Appstract\LushHttp\Request\LushRequest;
-use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Events\Dispatcher;
 
-class RequestEvent
+class RequestEvent extends Dispatcher
 {
-    use Dispatchable, SerializesModels;
+    use SerializesModels;
 
     public $request;
 

--- a/src/Events/RequestExceptionEvent.php
+++ b/src/Events/RequestExceptionEvent.php
@@ -3,12 +3,12 @@
 namespace Appstract\LushHttp\Events;
 
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Events\Dispatcher;
 use Appstract\LushHttp\Exception\LushRequestException;
 
-class RequestExceptionEvent
+class RequestExceptionEvent extends Dispatcher
 {
-    use Dispatchable, SerializesModels;
+    use SerializesModels;
 
     public $exception;
 

--- a/src/Events/ResponseEvent.php
+++ b/src/Events/ResponseEvent.php
@@ -4,11 +4,11 @@ namespace Appstract\LushHttp\Events;
 
 use Illuminate\Queue\SerializesModels;
 use Appstract\LushHttp\Response\LushResponse;
-use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Events\Dispatcher;
 
-class ResponseEvent
+class ResponseEvent extends Dispatcher
 {
-    use Dispatchable, SerializesModels;
+    use SerializesModels;
 
     public $response;
 


### PR DESCRIPTION
#### System configuration 
**OS**: Mac OS High Sierra
**Framework**: Lumen

#### Step to reproduce 
After install this package and make concerned configurations, execute `php artisan opcache:status`.

#### Error log 
    PHP Fatal error:  Trait 'Illuminate\Foundation\Events\Dispatchable' not found in 
    /Users/gentcys/Codes/nethappy/wn-voice/vendor/appstract/lush-http/src/Events/RequestEvent.php 
    on line 11

    Fatal error: Trait 'Illuminate\Foundation\Events\Dispatchable' not found in 
    /Users/gentcys/Codes/nethappy/wn-voice/vendor/appstract/lush-http/src/Events/RequestEvent.php 
    on line 11 

    In RequestEvent.php line 11:
    Trait 'Illuminate\Foundation\Events\Dispatchable' not found