### PR TITLE
remove default value and type hinting for magic methods

### DIFF
--- a/src/Lush.php
+++ b/src/Lush.php
@@ -151,7 +151,7 @@ class Lush
      *
      * @return \Appstract\LushHttp\Response\LushResponse
      */
-    public function __call($method, array $arguments = [])
+    public function __call($method, $arguments)
     {
         $scope = $this;
 

--- a/src/Response/LushResponse.php
+++ b/src/Response/LushResponse.php
@@ -153,7 +153,7 @@ class LushResponse implements JsonSerializable
      *
      * @return mixed
      */
-    public function __call($method, $arguments = [])
+    public function __call($method, $arguments)
     {
         return call_user_func_array([$this->getCollection(), $method], $arguments);
     }


### PR DESCRIPTION
I was writing some tests, and in creating a mock of this class I came across this error:

`ErrorException: Declaration of Mockery_1_Appstract_LushHttp_Lush::__call($method, array $args) should be compatible with Appstract\LushHttp\Lush::__call($method, array $arguments = Array)`

Looking at the signature of the `__call` methods, I noticed that default values had been entered.

Since this methods are always handled by php itself, and `$arguments` will always be an array, even if no arguments were passed to the called methods, to avoid mocking problems I've removed defaults and tipe hinting declarations.